### PR TITLE
LPS-121474

### DIFF
--- a/templates/base/scripts/liferay_entrypoint.sh
+++ b/templates/base/scripts/liferay_entrypoint.sh
@@ -23,8 +23,6 @@ function main {
 
 	execute_scripts /usr/local/liferay/scripts/pre-startup
 
-	set +e
-
 	trap 'handle_termination' TERM INT
 
 	start_liferay.sh &

--- a/templates/base/scripts/start_liferay.sh
+++ b/templates/base/scripts/start_liferay.sh
@@ -7,9 +7,9 @@ function main {
 
 	if [ "${LIFERAY_JPDA_ENABLED}" == "true" ]
 	then
-		${LIFERAY_HOME}/tomcat/bin/catalina.sh jpda run
+		exec ${LIFERAY_HOME}/tomcat/bin/catalina.sh jpda run
 	else
-		${LIFERAY_HOME}/tomcat/bin/catalina.sh run
+		exec ${LIFERAY_HOME}/tomcat/bin/catalina.sh run
 	fi
 }
 


### PR DESCRIPTION
Hi @timscottbell,

I've made some changes on the PR to make it a little bit simpler and to follow our so far undocumented coding guidelines.

Can you please check if my changes are correct? I have made some assumptions and I'd like to get your feedback on it:
# `set +e` should be default, I have removed it
# The two wait is only necessary if there's a chance that the first wait would get another signal (e.g. ctrl+c). In this case it's either ctrl+c and we can manually shut down the docker image or it's kubernetes sending the TERM, but it will wait 5 minutes before killing the container, new new signals should be sent within that 5 minutes as far as I understand.
# There's a very, very low chance that we trap, start a bash process in the background and before we get the PID there's a TERM signal as these are very fast actions. I think we could skip managing the ifs for these scenarios.

What do you think?

Thank you,
Zsolt